### PR TITLE
Support for 16.0 and New ANSI C lib/headers Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
 # node-daqmx
 
-I wanted to combine National Instruments data acquisition hardware with Node.js. This is not a 1-to-1 wrapper of the DAQmx C api. I have re-interpreted some of the structures to make using DAQmx a little easier, but tried to be faithful to the original concepts.
+I wanted to combine National Instruments data acquisition hardware with Node.js. This is not a 1-to-1 wrapper of the DAQmx C API. I have re-interpreted some of the structures to make using DAQmx a little easier, but tried to be faithful to the original concepts.
 
-If you need the full api, considering using [node-ffi](https://github.com/node-ffi/node-ffi) to load nicaiu.dll (from the daqmx driver installation) to access all the C API functions.
+If you need the full API, considering using [node-ffi](https://github.com/node-ffi/node-ffi) to load nicaiu.dll (from the daqmx driver installation) to access all the C API functions.
 
-## Pre-requisits
+## Dependencies
 
-- Everything needed to build Node.js addons.
+- Everything needed to build Node.js add-ons ([node-gyp and build tools for windows](https://github.com/nodejs/node-gyp/))
 - Latest [National Instruments DAQmx drivers](http://www.ni.com/download/ni-daqmx-14.5/5212/en/).
 - Either a physical NI device, or a virtual device created using their Measurement and Automation Explorer.
 
-The following examples assume the addon is loaded into the variable 'daqmx'.
+The following examples assume the add-on is loaded into the variable 'daqmx'.
+
+## Install
+
+```bash
+node-gyp rebuild # in root directory of repo
+node-gyp install
+```
 
 ## Devices
 
@@ -22,7 +29,7 @@ var devs = daqmx.devices();
 console.log(devs);
 ```
 
-returns an array of objects of each device with properties: E.G.
+Returns an array of objects of each device with properties: E.G.
 ```JavaScript
 [{
     name: "Dev1",
@@ -36,7 +43,7 @@ returns an array of objects of each device with properties: E.G.
 
 ## AI Voltage Task
 
-The minimal configuration to acquire a sample must have defined the channels to acquire on, and the timing of the samples. Specifying the channels separatly as an array will cause the read to return a 2D array, where the first index is the channels (in the same order), and second index is sample #. There can typically be only one task of each type running per physical device because of how the signals are digitized. There's usually only 1 ADC (or DAC), which is split between the channels.
+The minimal configuration to acquire a sample must have defined the channels to acquire on, and the timing of the samples. Specifying the channels separately as an array will cause the read to return a 2D array, where the first index is the channels (in the same order), and second index is sample #. There can typically be only one task of each type running per physical device because of how the signals are digitized. There's usually only 1 ADC (or DAC), which is split between the channels.
 
 ```JavaScript
 // read 10 samples from 2 channels at 10,000Hz sample rate
@@ -62,7 +69,7 @@ var x = task.read(); // infinite timeout
 console.log(x);
 ```
 
-Alternatly, if the terminals are consecutive, they can be specified in a single input. E.G. the following will acquire from 4 terminals (ai0, ai1, ai2, ai3).
+Alternately, if the terminals are consecutive, they can be specified in a single input. E.G. the following will acquire from 4 terminals (ai0, ai1, ai2, ai3).
 
 ```JavaScript
 var task = new daqmx.AIVoltageTask({
@@ -81,13 +88,13 @@ var task = new daqmx.AIVoltageTask({
 The reading of samples can also be done in the Node.js io loop so that it doesn't block the program execution.
 
 ```JavaScript
-// do a read asyncronously
+// do a read asynchronously
 var readAsync = function(callback) {
 
     process.nextTick(function(){
         // call canRead() tests if all samples can be read
         if (task.canRead()) {
-            var data = task.read(0.0); // should read immediatly
+            var data = task.read(0.0); // should read immediately
 
             callback(data);
         }else{
@@ -129,14 +136,14 @@ var task = new daqmx.AIVoltageTask({
     },
 
     startTiming: { // optional timing for when to start the task
-        type: "digital", // analog, or digital
+        type: "digital", // analogue, or digital
         terminal: "PFI0",
         triggerSlope: "falling" // optional, default rising
     }
 });
 ```
 
-To do a finite sample of a single channel using an external clock, and an external analog start trigger including hysteresis.
+To do a finite sample of a single channel using an external clock, and an external analogue start trigger including hysteresis.
 
 ```JavaScript
 var task = new daqmx.AIVoltageTask({
@@ -163,8 +170,8 @@ var task = new daqmx.AIVoltageTask({
         type: "analog",
         terminal: "APFI0",
         triggerSlope: "rising", // optional, default rising
-        triggerLevel: 1.0, // analog trigger only in volts
-        hysteresis: 1.0 // optional for analog trigger only, default 0.0
+        triggerLevel: 1.0, // analogue trigger only in volts
+        hysteresis: 1.0 // optional for analogue trigger only, default 0.0
     }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you need the full API, considering using [node-ffi](https://github.com/node-f
 ## Dependencies
 
 - Everything needed to build Node.js add-ons ([node-gyp and build tools for windows](https://github.com/nodejs/node-gyp/))
-- Latest [National Instruments DAQmx drivers](http://www.ni.com/download/ni-daqmx-14.5/5212/en/).
+- Latest [National Instruments DAQmx drivers](http://www.ni.com/download/ni-daqmx-16.0/6120/en/).
 - Either a physical NI device, or a virtual device created using their Measurement and Automation Explorer.
 
 The following examples assume the add-on is loaded into the variable 'daqmx'.
@@ -18,6 +18,14 @@ The following examples assume the add-on is loaded into the variable 'daqmx'.
 node-gyp rebuild # in root directory of repo
 node-gyp install
 ```
+
+Or just run `npm install`
+
+**This is a fork of [kcdodd's](https://github.com/kcdodd/node-daqmx) repository
+to bring it upto date and provide 64bit support. By default it is for 64bit, to use it with a 32bit system,
+change line 7 in 'binding.gpy' to:**
+
+`"libraries": [ "C:\Program Files (x86)\National Instruments\Shared\ExternalCompilerSupport\C\lib32\msvc\NIDAQmx.lib" ]`
 
 ## Devices
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,9 +3,8 @@
         {
             "target_name": "nodedaqmx",
             "sources": [ "./src/nodedaqmx.cc", "./src/AIVoltageTask.cc", "./src/error.cc"],
-            "include_dirs": ["C:\Program Files (x86)\National Instruments\NI-DAQ\DAQmx ANSI C Dev\include"],
-            "libraries": [ "C:\Program Files (x86)\National Instruments\NI-DAQ\DAQmx ANSI C Dev\lib\msvc\NIDAQmx.lib" ]
-
+            "include_dirs": ["C:\Program Files (x86)\National Instruments\Shared\ExternalCompilerSupport\C\include"],
+            "libraries": [ "C:\Program Files (x86)\National Instruments\Shared\ExternalCompilerSupport\C\lib64\msvc\NIDAQmx.lib" ]
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "node-daqmx",
+  "version": "1.1.0",
+  "description": "Node wrapper for National Instruments DAQmx C API",
+  "main": "testdaq.js",
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {
+    "test": "node testdaq.js",
+    "install": "node-gyp rebuild"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tuna-f1sh/node-daqmx.git"
+  },
+  "keywords": [
+    "National",
+    "Instruments",
+    "DAQmx",
+    "DAQ"
+  ],
+  "author": "Carter Dodd",
+  "contributors": ["John Whittington <npm@jbrengineering.co.uk> (http://www.jbrengineering.co.uk)"],
+  "license": "GPL-3.0",
+  "gypfile": true,
+  "bugs": {
+    "url": "https://github.com/tuna-f1sh/node-daqmx/issues"
+  },
+  "homepage": "https://github.com/tuna-f1sh/node-daqmx#readme"
+}


### PR DESCRIPTION
Relates to #1 

"I have created a fork, which builds on 64bit systems using the new 'Shared>ExternalCompilerSupport>C' folder.

The folder contains libs for both 32bit and 64bit systems and updated header files. I have changed binding.gyp to use the new path with 64bit lib by default, and a note for users on how to change it to 32bit lib. I've also updated the README with the latest NIDAQmx 16.0 download."