### PR TITLE
Add support for newer Node versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ I wanted to combine National Instruments data acquisition hardware with Node.js.
 
 If you need the full API, considering using [node-ffi](https://github.com/node-ffi/node-ffi) to load nicaiu.dll (from the daqmx driver installation) to access all the C API functions.
 
+Now you can build this library using Node 12 (and probably older versions that wouldn't work because **NewInstance** got deprecated).
+
 ## Dependencies
 
 - Everything needed to build Node.js add-ons ([node-gyp and build tools for windows](https://github.com/nodejs/node-gyp/))
@@ -38,6 +40,7 @@ console.log(devs);
 ```
 
 Returns an array of objects of each device with properties: E.G.
+
 ```JavaScript
 [{
     name: "Dev1",

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,9 +2,9 @@
     "targets": [
         {
             "target_name": "nodedaqmx",
-            "sources": [ "./src/nodedaqmx.cc", "./src/AIVoltageTask.cc", "./src/error.cc"],
-            "include_dirs": ["C:\Program Files (x86)\National Instruments\Shared\ExternalCompilerSupport\C\include"],
-            "libraries": [ "C:\Program Files (x86)\National Instruments\Shared\ExternalCompilerSupport\C\lib64\msvc\NIDAQmx.lib" ]
+            "sources": ["./src/nodedaqmx.cc", "./src/AIVoltageTask.cc", "./src/error.cc"],
+            "include_dirs": ["C:\Program Files (x86)\National Instruments\Shared\ExternalCompilerSupport\C\include", "<!(node -e \"require('nan')\")"],
+            "libraries": ["C:\Program Files (x86)\National Instruments\Shared\ExternalCompilerSupport\C\lib64\msvc\NIDAQmx.lib"]
         }
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-daqmx",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "http://10.2.1.4:4873/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.1.0",
   "description": "Node wrapper for National Instruments DAQmx C API",
   "main": "testdaq.js",
-  "dependencies": {},
+  "dependencies": {
+    "nan": "^2.14.0"
+  },
   "devDependencies": {},
   "scripts": {
     "test": "node testdaq.js",
@@ -20,7 +22,9 @@
     "DAQ"
   ],
   "author": "Carter Dodd",
-  "contributors": ["John Whittington <npm@jbrengineering.co.uk> (http://www.jbrengineering.co.uk)"],
+  "contributors": [
+    "John Whittington <npm@jbrengineering.co.uk> (http://www.jbrengineering.co.uk)"
+  ],
   "license": "GPL-3.0",
   "gypfile": true,
   "bugs": {

--- a/src/AIVoltageTask.cc
+++ b/src/AIVoltageTask.cc
@@ -1,3 +1,4 @@
+#include <nan.h>
 #include "AIVoltageTask.h"
 #include "error.h"
 
@@ -320,7 +321,7 @@ void AIVoltageTask::New(const FunctionCallbackInfo<Value>& args) {
         const int argc = 1;
         Local<Value> argv[argc] = { args[0] };
         Local<Function> cons = Local<Function>::New(isolate, constructor);
-        args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+        args.GetReturnValue().Set(Nan::NewInstance(cons,argc, argv).ToLocalChecked());
     }
 
 


### PR DESCRIPTION
Building of this library was impossible under Node 12 because `AIVoltageTask.cc` depended on the deprecated function **NewInstance**. Thankfully, with the [Nan library](https://github.com/nodejs/nan) we can use the old code with a small change on how this function is called. 