### PR TITLE
Fix NewInstance() compilation error

### DIFF
--- a/src/AIVoltageTask.cc
+++ b/src/AIVoltageTask.cc
@@ -319,11 +319,10 @@ void AIVoltageTask::New(const FunctionCallbackInfo<Value>& args) {
         // Invoked as plain function `ReadBuffer64(...)`, turn into construct call.
         const int argc = 1;
         Local<Value> argv[argc] = { args[0] };
+        Local<Context> context = isolate->GetCurrentContext();
         Local<Function> cons = Local<Function>::New(isolate, constructor);
-        args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+        args.GetReturnValue().Set(cons->NewInstance(context, argc, argv).ToLocalChecked());
     }
-
-
 }
 
 // DAQmxStartTask


### PR DESCRIPTION
- New node versions need `context` as parameter.

Node API documentation: https://v8docs.nodesource.com/node-10.15/d5/d54/classv8_1_1_function.html#a3fc1404644188254d6ab1aae7304579e

Reference: http://doc.codingdict.com/nodejs-ref/addons.html